### PR TITLE
Add support for 'input' to accept jQuery objects

### DIFF
--- a/apprise-1.5.full.js
+++ b/apprise-1.5.full.js
@@ -48,6 +48,9 @@ function apprise(string, args, callback) {
             if (typeof (args['input']) == 'string') {
                 inner.append('<div class="aInput"><input type="text" class="aTextbox" t="aTextbox" value="' + args['input'] + '" /></div>');
             }
+            if (typeof (args['input']) == 'object') {
+                inner.append($('<div class="aInput"></div>').append(args['input']));
+            }
             else {
                 inner.append('<div class="aInput"><input type="text" class="aTextbox" t="aTextbox" /></div>');
             }


### PR DESCRIPTION
With this commit one can freely set up the input area while retaining Apprise's simplicity.

Example:
apprise("Password:",
        {
          'input': $('<input type="password" class="aTextbox" name="pwd" size="20" />');
        },
        function(r) { });
