### PR TITLE
Position relative to window height/width

### DIFF
--- a/apprise-1.5.full.js
+++ b/apprise-1.5.full.js
@@ -24,8 +24,8 @@ function apprise(string, args, callback) {
         { if (typeof args[index] == "undefined") args[index] = default_args[index]; }
     }
 
-    var aHeight = $(document).height(),
-		aWidth = $(document).width(),
+    var aHeight = $(window).height(),
+		aWidth = $(window).width(),
 		apprise = $('<div class="appriseOuter"></div>'),
 		overlay = $('<div class="appriseOverlay" id="aOverlay"></div>'),
 		inner = $('<div class="appriseInner"></div>'),


### PR DESCRIPTION
When the document is taller than the current window, apprise is positioned below the bottom of the screen. This fix uses `$(window).height()` and `.width()` instead of `$(document)` to position it relative to the window height instead of of the content height.
