### PR TITLE
Update apprise.css

### DIFF
--- a/apprise.css
+++ b/apprise.css
@@ -3,8 +3,10 @@
 	position:fixed;
 	top:0;
 	left:0;
-	background:rgba(0, 0, 0, 0.3);
-	display:none;
+	background-color: #000;
+        zoom: 1;
+	filter: alpha(opacity = 30);
+        opacity: 0.3;
 	}
 .appriseOuter
 	{


### PR DESCRIPTION
.appriseOverlay does not work on IE 9 and below. Changed the style rules for .appriseOverlay so that it works cross-browser.

This will make apprise compatible with IE 9 and below.
